### PR TITLE
feat(auth): implement redirect path handling in ProtectedRoute

### DIFF
--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -1,8 +1,9 @@
-import { Navigate } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 
 const ProtectedRoute = ({ children }) => {
   const { currentUser, loading } = useAuth();
+  const location = useLocation();
 
   // Show loading state while checking authentication
   if (loading) {
@@ -20,6 +21,8 @@ const ProtectedRoute = ({ children }) => {
 
   // Redirect to login if not authenticated
   if (!currentUser) {
+    // Save the current location to localStorage before redirecting
+    localStorage.setItem('lifetracker_redirectPath', location.pathname + location.search);
     return <Navigate to="/login" />;
   }
 

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -79,7 +79,15 @@ const Login = () => {
     try {
       // Pass the rememberMe preference to login function
       await login(formData.username, formData.password, rememberMe);
-      navigate('/'); // Redirect to homepage after login
+      
+      // Check if there's a saved redirect path
+      const redirectPath = localStorage.getItem('lifetracker_redirectPath');
+      
+      // Navigate to the saved path or home page
+      navigate(redirectPath || '/');
+      
+      // Remove the saved path after use
+      localStorage.removeItem('lifetracker_redirectPath');
     } catch (err) {
       console.log("Login error:", err.response?.data);
       if (err.response?.data?.verification_required) {


### PR DESCRIPTION
This pull request enhances the user experience by implementing a feature to redirect users back to their originally intended page after logging in. The changes involve storing the user's intended path before redirecting them to the login page and navigating back to that path upon successful login.

### Enhancements to user redirection:

* **`src/components/ProtectedRoute.jsx`:** 
  - Added `useLocation` to capture the current path and query string.
  - Before redirecting unauthenticated users to the login page, the current location is saved to `localStorage` under the key `lifetracker_redirectPath`.

* **`src/pages/Login.jsx`:**
  - Updated the login logic to check for a saved redirect path in `localStorage`. If one exists, the user is redirected to that path after logging in; otherwise, they are redirected to the homepage. The saved path is then cleared from `localStorage`.…gin components